### PR TITLE
Fix Stack Use After Scope Address Sanitizer Error

### DIFF
--- a/spsc_queue.hpp
+++ b/spsc_queue.hpp
@@ -356,7 +356,7 @@ struct scope_guard {
     scope_guard(Callable&& f) : _f(std::forward<Callable>(f)) {}
     ~scope_guard() {
         if (should_call()) {
-            std::forward<Callable>(_f)();
+            _f();
         }
     };
     
@@ -390,7 +390,7 @@ private:
     }
 
 #endif
-    Callable&& _f;
+    Callable _f;
 };
 
 template<typename Callable>


### PR DESCRIPTION
Address sanitizer reports the following error:

```
Address 0x7fff5776c8a0 is located in stack of thread T0 at offset 96 in frame
    #0 0x5d9cff in unsigned long deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::consume_all<deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::~spsc_queue()::'lambda'(std::array<std::byte, 1ul>*)>(deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::~spsc_queue()::'lambda'(std::array<std::byte, 1ul>*)&&) /proc/self/cwd/external/com_github_deaod_spsc_queue/spsc_queue.hpp:1269

  This frame has 4 object(s):
    [32, 40) 'head' (line 1275)
    [64, 72) 'g' (line 1279)
    [96, 112) 'ref.tmp' (line 1279) <== Memory access at offset 96 is inside this variable
    [128, 136) 'elem' (line 1284)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /proc/self/cwd/external/com_github_deaod_spsc_queue/spsc_queue.hpp:1279 in unsigned long deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::consume_all<deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::~spsc_queue()::'lambda'(std::array<std::byte, 1ul>*)>(deaod::spsc_queue<std::array<std::byte, 1ul>, 2ul, 7>::~spsc_queue()::'lambda'(std::array<std::byte, 1ul>*)&&)::'lambda'()::operator()() const
Shadow bytes around the buggy address:
  0x10006aee58c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee58d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee58e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee58f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee5900: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f2 f2 f2
=>0x10006aee5910: 00 f2 f2 f2[f8]f8 f2 f2 f8 f3 f3 f3 00 00 00 00
  0x10006aee5920: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee5930: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee5940: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee5950: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006aee5960: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 01 f3 f3 f3
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==27196==ABORTING
```

This PR introduces fix for this error.